### PR TITLE
Bump System.Net.Http from 4.3.0 to 4.3.4 in /TacoEyeTrack

### DIFF
--- a/TacoEyeTrack/packages.config
+++ b/TacoEyeTrack/packages.config
@@ -107,7 +107,7 @@
   <package id="System.Linq" version="4.3.0" targetFramework="net472" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net472" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net472" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />


### PR DESCRIPTION
Bumps System.Net.Http from 4.3.0 to 4.3.4.

---
updated-dependencies:
- dependency-name: System.Net.Http dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>